### PR TITLE
feat(auth): integrate Clerk (App Router) + protect dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Open the Command line or Terminal.
 2.  **Clone your forked repository**
     -   Replace `[username]` with your actual GitHub username in the command below.
     ```bash
-    git clone [https://github.com/](https://github.com/)[username]/Darzi-AI-Resume-Suite
+    git clone https://github.com/[username]/Darzi-AI-Resume-Suite
     ```
 
 3.  **Move to the project folder**
@@ -74,6 +74,31 @@ Open the Command line or Terminal.
     ```bash
     code .
     ```
+
+## 🧑‍💻 Local Development (Frontend)
+
+1. Copy env example and create your local env
+   ```bash
+   cp frontend/.env.example frontend/.env.local
+   ```
+2. Edit `frontend/.env.local` and set your own Clerk keys
+   - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=`
+   - `CLERK_SECRET_KEY=`
+   Do not commit `.env.local` (it is gitignored).
+3. Install and run the frontend
+   ```bash
+   cd frontend
+   pnpm install
+   pnpm dev
+   ```
+4. Open the app
+   - http://localhost:3000
+5. Auth routes (for testing)
+   - Sign In: `/sign-in`
+   - Sign Up: `/sign-up`
+   - After sign-in: `/Dashboard` (protected; signed-out users are redirected to `/sign-in`)
+
+> Backend is optional for UI testing. If needed, see `backend/README.md` for setup.
 
 ## 🤝 Contributing
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,17 @@
+# Clerk Environment Variables (example)
+# Copy this file to .env.local and fill in the values locally OR use Vercel CLI to pull them:
+#   vercel login
+#   vercel link
+#   vercel env pull .env.local
+
+# Public (still set via env; do NOT commit real values)
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
+
+# Secret (server-side only; never expose in client code)
+CLERK_SECRET_KEY=
+
+# Optional routes (kept for consistency with app routing)
+NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
+NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
+NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL=/Dashboard
+NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/Dashboard

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -19,6 +19,10 @@ yarn-error.log*
 # env files
 .env*
 
+# allowed example envs to be tracked
+!.env.example
+!**/.env.example
+
 # vercel
 .vercel
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -20,6 +20,22 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Environment Variables (Clerk)
+
+1. Copy `.env.example` to `.env.local` and fill in values locally. Do not commit `.env.local`.
+2. For shared environments, store keys in your platform secrets:
+   - Vercel: Project Settings → Environment Variables
+   - GitHub Actions: Settings → Secrets and variables → Actions
+3. Optionally, developers can pull environment variables from Vercel:
+
+```bash
+vercel login
+vercel link
+vercel env pull .env.local
+```
+
+> Never commit real keys to the repo. The publishable key is public at runtime but should still be set via env; the secret key must remain server-only.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/frontend/app/Dashboard/components/header.tsx
+++ b/frontend/app/Dashboard/components/header.tsx
@@ -1,4 +1,6 @@
 import { User, Settings, Search, Bell } from 'lucide-react';
+import Link from 'next/link';
+import { SignedIn, SignedOut, UserButton } from '@clerk/nextjs';
 
 export default function Header() {
     return (
@@ -13,10 +15,15 @@ export default function Header() {
                 <input type="text" placeholder="Type here..." className="bg-transparent pl-9 text-sm focus:outline-none text-white" />
             </div>
             <div className="flex items-center space-x-4 ml-4">
-                <a href="#" className="flex items-center text-sm text-gray-300 hover:text-white">
-                    <User className="h-4 w-4 mr-1" />
-                    Sign In
-                </a>
+                <SignedOut>
+                    <Link href="/sign-in" className="flex items-center text-sm text-gray-300 hover:text-white">
+                        <User className="h-4 w-4 mr-1" />
+                        Sign In
+                    </Link>
+                </SignedOut>
+                <SignedIn>
+                    <UserButton />
+                </SignedIn>
                 <a href="#"><Settings className="h-5 w-5 text-gray-400 hover:text-white active:animate-spin" /></a> {/* I like the spin animation, dont remove it. -Abhash */}
                 <a href="#"><Bell className="h-5 w-5 text-gray-400 hover:text-white" /></a>
             </div>

--- a/frontend/app/Dashboard/page.tsx
+++ b/frontend/app/Dashboard/page.tsx
@@ -18,6 +18,7 @@ import {
   BrainCircuit,
   ListChecks,
 } from "lucide-react";
+import { SignedIn, SignedOut, RedirectToSignIn } from "@clerk/nextjs";
 
 type StatData = {
   resumesCreated: number;
@@ -383,68 +384,74 @@ export default function App() {
   }
 
   return (
-    <div className="bg-black text-white min-h-screen font-sans">
-      <Sidebar onToggle={setSidebarCollapsed} />
-      <main
-        className={`overflow-y-auto transition-all duration-300 ease-in-out ${
-          sidebarCollapsed ? "ml-20" : "ml-64"
-        }`}
-      >
-        <Header />
-        <div className="p-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
-            <StatCard
-              title="Resumes Created"
-              value={stats?.resumesCreated || 0}
-              change="+2"
-              changeType="increase"
-              icon={<FileText className="text-black" />}
-            />
-            <StatCard
-              title="Avg. ATS Score"
-              value={`${stats?.avgAtsScore || 0}%`}
-              change="+5%"
-              changeType="increase"
-              icon={<Target className="text-black" />}
-            />
-            <StatCard
-              title="Keywords Matched"
-              value={stats?.keywordsMatched || 0}
-              change="+12"
-              changeType="increase"
-              icon={<ListChecks className="text-black" />}
-            />
-            <StatCard
-              title="Templates Used"
-              value={stats?.templatesUsed || 0}
-              icon={<BarChart3 className="text-black" />}
-            />
-          </div>
+    <>
+      <SignedIn>
+        <div className="bg-black text-white min-h-screen font-sans">
+          <Sidebar onToggle={setSidebarCollapsed} />
+          <main
+            className={`overflow-y-auto transition-all duration-300 ease-in-out ${
+              sidebarCollapsed ? "ml-20" : "ml-64"
+            }`}
+          >
+            <Header />
+            <div className="p-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
+                <StatCard
+                  title="Resumes Created"
+                  value={stats?.resumesCreated || 0}
+                  change="+2"
+                  changeType="increase"
+                  icon={<FileText className="text-black" />}
+                />
+                <StatCard
+                  title="Avg. ATS Score"
+                  value={`${stats?.avgAtsScore || 0}%`}
+                  change="+5%"
+                  changeType="increase"
+                  icon={<Target className="text-black" />}
+                />
+                <StatCard
+                  title="Keywords Matched"
+                  value={stats?.keywordsMatched || 0}
+                  change="+12"
+                  changeType="increase"
+                  icon={<ListChecks className="text-black" />}
+                />
+                <StatCard
+                  title="Templates Used"
+                  value={stats?.templatesUsed || 0}
+                  icon={<BarChart3 className="text-black" />}
+                />
+              </div>
 
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
-            <div className="lg:col-span-1">
-              <WelcomeCard />
-            </div>
-            <div className="lg:col-span-1">
-              <OverallAtsScoreCard score={stats?.avgAtsScore || 0} />
-            </div>
-            <div className="lg:col-span-1">
-              <RecentActivityCard />
-            </div>
-          </div>
+              <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
+                <div className="lg:col-span-1">
+                  <WelcomeCard />
+                </div>
+                <div className="lg:col-span-1">
+                  <OverallAtsScoreCard score={stats?.avgAtsScore || 0} />
+                </div>
+                <div className="lg:col-span-1">
+                  <RecentActivityCard />
+                </div>
+              </div>
 
-          <div className="grid grid-cols-1 xl:grid-cols-3 gap-6 mb-6">
-            <AtsScoreHistoryCard />
-            <KeywordAnalysisCard data={keywords} />
-          </div>
+              <div className="grid grid-cols-1 xl:grid-cols-3 gap-6 mb-6">
+                <AtsScoreHistoryCard />
+                <KeywordAnalysisCard data={keywords} />
+              </div>
 
-          <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
-            <MyResumesCard data={resumes} />
-            <ActionItemsCard data={actionItems} />
-          </div>
+              <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+                <MyResumesCard data={resumes} />
+                <ActionItemsCard data={actionItems} />
+              </div>
+            </div>
+          </main>
         </div>
-        <FooterSection />
-      </main>
-    </div>
+      </SignedIn>
+      <SignedOut>
+        <RedirectToSignIn />
+      </SignedOut>
+    </>
   );
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { ClerkProvider } from "@clerk/nextjs";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -23,12 +24,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="dark">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
-      </body>
-    </html>
+    <ClerkProvider>
+      <html lang="en" className="dark">
+        <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+          {children}
+        </body>
+      </html>
+    </ClerkProvider>
   );
 }

--- a/frontend/app/sign-in/[[...sign-in]]/page.tsx
+++ b/frontend/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,0 +1,9 @@
+import { SignIn } from "@clerk/nextjs";
+
+export default function Page() {
+  return (
+    <div className="min-h-[calc(100vh-4rem)] flex items-center justify-center p-4">
+      <SignIn routing="path" path="/sign-in" />
+    </div>
+  );
+}

--- a/frontend/app/sign-up/[[...sign-up]]/page.tsx
+++ b/frontend/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,0 +1,9 @@
+import { SignUp } from "@clerk/nextjs";
+
+export default function Page() {
+  return (
+    <div className="min-h-[calc(100vh-4rem)] flex items-center justify-center p-4">
+      <SignUp routing="path" path="/sign-up" />
+    </div>
+  );
+}

--- a/frontend/components/header.tsx
+++ b/frontend/components/header.tsx
@@ -75,13 +75,14 @@ const HeroHeader = () => {
                                     ))}
                                 </ul>
                             </div>
+                            {/* Keep existing buttons, just wire to Clerk routes */}
                             <div className="flex w-full flex-col space-y-3 sm:flex-row sm:gap-3 sm:space-y-0 md:w-fit">
                                 <Button
                                     asChild
                                     variant="outline"
                                     size="sm"
                                     className={cn(isScrolled && 'lg:hidden')}>
-                                    <Link href="#">
+                                    <Link href="/sign-in">
                                         <span>Login</span>
                                     </Link>
                                 </Button>
@@ -89,7 +90,7 @@ const HeroHeader = () => {
                                     asChild
                                     size="sm"
                                     className={cn(isScrolled && 'lg:hidden')}>
-                                    <Link href="#">
+                                    <Link href="/sign-up">
                                         <span>Sign Up</span>
                                     </Link>
                                 </Button>
@@ -97,7 +98,7 @@ const HeroHeader = () => {
                                     asChild
                                     size="sm"
                                     className={cn(isScrolled ? 'lg:inline-flex' : 'hidden')}>
-                                    <Link href="#">
+                                    <Link href="/Dashboard">
                                         <span>Get Started</span>
                                     </Link>
                                 </Button>

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,12 @@
+import { clerkMiddleware } from "@clerk/nextjs/server";
+
+export default clerkMiddleware();
+
+export const config = {
+  matcher: [
+    // Skip Next.js internals and all static files, unless found in search params
+    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
+    // Always run for API routes
+    "/(api|trpc)(.*)",
+  ],
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@clerk/nextjs": "^6.30.0",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "class-variance-authority": "^0.7.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@clerk/nextjs':
+        specifier: ^6.30.0
+        version: 6.30.0(next@15.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-label':
         specifier: ^2.1.7
         version: 2.1.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -82,6 +85,41 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@clerk/backend@2.7.0':
+    resolution: {integrity: sha512-YrZwRd1X9Am1HGlIx01LoENZ5S7zDBmvHw0srUI5EhNBNY1HCWAd8iBF678o1qV95/sOB27A7BiKJiDIgnTiZg==}
+    engines: {node: '>=18.17.0'}
+
+  '@clerk/clerk-react@5.40.0':
+    resolution: {integrity: sha512-gRhubPU/U/XEjZv2AujFz5aKKJ5C4ogWxzHILOUjrENJI/EiAyO2B7UtWirW2AC6bHnROoRUQFn0CTi4LVlbig==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-0
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-0
+
+  '@clerk/nextjs@6.30.0':
+    resolution: {integrity: sha512-rQePjoKWUx7K/oYpnlPB2+kgsJdPJtWbIwA2ePyyqY1pbKTlB/SwhzMA+tT8fe6eRPUI0Q6cgpeq43DEEIcZig==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      next: ^13.5.7 || ^14.2.25 || ^15.2.3
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-0
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-0
+
+  '@clerk/shared@3.18.1':
+    resolution: {integrity: sha512-l/8+X1gM9+Se87USn55B0ZKeSrFgy0ZYHzAptUc1Fgmfyved90JX7n5QgY66DuqbdM5OfGbRNFiCsI2khAgmrA==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-0
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@clerk/types@4.74.0':
+    resolution: {integrity: sha512-9Wt2dWyCtCp2FngRkbHuQXPMttRjvGb77bmyCdGkPmNqQIZp7m4AZRdPtXhcGgxzaAYJkK6psgolbvuKDk+1jA==}
+    engines: {node: '>=18.17.0'}
 
   '@emnapi/core@1.4.5':
     resolution: {integrity: sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==}
@@ -411,6 +449,9 @@ packages:
 
   '@rushstack/eslint-patch@1.12.0':
     resolution: {integrity: sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -822,6 +863,10 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -871,6 +916,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
@@ -1060,6 +1109,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -1140,6 +1192,9 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob-to-regexp@0.4.1:
+    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -1325,6 +1380,10 @@ packages:
   jiti@2.5.1:
     resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
     hasBin: true
+
+  js-cookie@3.0.5:
+    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
+    engines: {node: '>=14'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1706,6 +1765,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -1755,6 +1817,12 @@ packages:
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -1811,6 +1879,11 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  swr@2.3.4:
+    resolution: {integrity: sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   tailwind-merge@3.3.1:
     resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}
@@ -1887,6 +1960,11 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-sync-external-store@1.5.0:
+    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -1928,6 +2006,53 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
+
+  '@clerk/backend@2.7.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@clerk/shared': 3.18.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@clerk/types': 4.74.0
+      cookie: 1.0.2
+      standardwebhooks: 1.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@clerk/clerk-react@5.40.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@clerk/shared': 3.18.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@clerk/types': 4.74.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      tslib: 2.8.1
+
+  '@clerk/nextjs@6.30.0(next@15.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@clerk/backend': 2.7.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@clerk/clerk-react': 5.40.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@clerk/shared': 3.18.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@clerk/types': 4.74.0
+      next: 15.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      server-only: 0.0.1
+      tslib: 2.8.1
+
+  '@clerk/shared@3.18.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@clerk/types': 4.74.0
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.5
+      std-env: 3.9.0
+      swr: 2.3.4(react@19.1.0)
+    optionalDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@clerk/types@4.74.0':
+    dependencies:
+      csstype: 3.1.3
 
   '@emnapi/core@1.4.5':
     dependencies:
@@ -2191,6 +2316,8 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.12.0': {}
+
+  '@stablelib/base64@1.0.1': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -2614,6 +2741,8 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  cookie@1.0.2: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -2663,6 +2792,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  dequal@2.0.3: {}
 
   detect-libc@2.0.4: {}
 
@@ -3005,6 +3136,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -3094,6 +3227,8 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob-to-regexp@0.4.1: {}
 
   globals@14.0.0: {}
 
@@ -3275,6 +3410,8 @@ snapshots:
       set-function-name: 2.0.2
 
   jiti@2.5.1: {}
+
+  js-cookie@3.0.5: {}
 
   js-tokens@4.0.0: {}
 
@@ -3632,6 +3769,8 @@ snapshots:
 
   semver@7.7.2: {}
 
+  server-only@0.0.1: {}
+
   set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
@@ -3727,6 +3866,13 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
+  std-env@3.9.0: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -3796,6 +3942,12 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  swr@2.3.4(react@19.1.0):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.1.0
+      use-sync-external-store: 1.5.0(react@19.1.0)
 
   tailwind-merge@3.3.1: {}
 
@@ -3911,6 +4063,10 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-sync-external-store@1.5.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   which-boxed-primitive@1.1.1:
     dependencies:


### PR DESCRIPTION
# Added Authentication 
- Ensure clerkMiddleware in middleware.ts with correct matcher
- Wrap app with <ClerkProvider> in app/layout.tsx
- Wire existing header buttons to /sign-in, /sign-up, and /Dashboard
- Protect /Dashboard: redirect signed-out users to /sign-in
- Add frontend/.env.example and allow it via .gitignore
- Update README with simple dev setup (copy .env.example -> .env.local)