### PR TITLE
Implemented latex editor and preview components in the resume editor page and added a footer section to both the dashboard and resume editor pages.

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -291,31 +291,6 @@ const MyResumesCard = ({ data }: { data: Resume[] }) => (
   </Card>
 );
 
-// const ActionItemsCard = ({ data }: { data: ActionItem[] }) => (
-//   <Card>
-//     <h4 className="font-bold text-white">AI Action Items</h4>
-//     <p className="text-sm text-gray-400 flex items-center">
-//       <ArrowUp className="h-4 w-4 text-gray-300 mr-1" /> Suggestions to improve
-//       your score
-//     </p>
-//     <div className="mt-6 space-y-6">
-//       {data.map((item, index) => (
-//         <div key={index} className="flex items-start">
-//           <div className="p-2 bg-gray-800 rounded-full mr-4">
-//             {React.cloneElement(item.icon, {
-//               className: "text-gray-300",
-//             } as React.HTMLAttributes<SVGElement>)}
-//           </div>
-//           <div>
-//             <p className="text-sm font-bold text-white">{item.text}</p>
-//             <p className="text-xs text-gray-400">{item.suggestion}</p>
-//           </div>
-//         </div>
-//       ))}
-//     </div>
-//   </Card>
-// );
-
 export default function App() {
   const [stats, setStats] = useState<StatData | null>(null);
   const [keywords, setKeywords] = useState<KeywordData[]>([]);
@@ -414,35 +389,6 @@ export default function App() {
           >
             <Header pageName="Dashboard" />
             <div className="p-4">
-              {/* <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-6">
-                <StatCard
-                  title="Resumes Created"
-                  value={stats?.resumesCreated || 0}
-                  change="+2"
-                  changeType="increase"
-                  icon={<FileText className="text-black" />}
-                />
-                <StatCard
-                  title="Avg. ATS Score"
-                  value={`${stats?.avgAtsScore || 0}%`}
-                  change="+5%"
-                  changeType="increase"
-                  icon={<Target className="text-black" />}
-                />
-                <StatCard
-                  title="Keywords Matched"
-                  value={stats?.keywordsMatched || 0}
-                  change="+12"
-                  changeType="increase"
-                  icon={<ListChecks className="text-black" />}
-                />
-                <StatCard
-                  title="Templates Used"
-                  value={stats?.templatesUsed || 0}
-                  icon={<BarChart3 className="text-black" />}
-                />
-              </div> */}
-
               <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
                 <div className="lg:col-span-1">
                   <WelcomeCard name={displayName} />
@@ -459,12 +405,7 @@ export default function App() {
                 <AtsScoreHistoryCard />
                 <KeywordAnalysisCard data={keywords} />
               </div>
-
-              {/* <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
-                <MyResumesCard data={resumes} />
-                <ActionItemsCard data={actionItems} />
-              </div> */}
-              {/* <FooterSection /> */}
+              <FooterSection />
             </div>
           </main>
         </div>

--- a/frontend/app/resume-editor/components/LaTeXEditor.tsx
+++ b/frontend/app/resume-editor/components/LaTeXEditor.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+// Dynamically import Monaco Editor to avoid SSR issues
+const MonacoEditor = dynamic(() => import("@monaco-editor/react"), {
+  ssr: false,
+});
+
+interface LaTeXEditorProps {
+  latexCode: string;
+  onCodeChange: (code: string) => void;
+}
+
+export default function LaTeXEditor({ latexCode, onCodeChange }: LaTeXEditorProps) {
+  return (
+    <section className="bg-white/5 border border-white/10 rounded-xl p-5">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="font-bold text-sm tracking-wide">LATEX CODE EDITOR</h2>
+      </div>
+      <div className="h-96 border border-white/10 rounded-md overflow-hidden">
+        <MonacoEditor
+          height="100%"
+          language="latex"
+          theme="vs-dark"
+          value={latexCode}
+          onChange={(value) => {
+            if (value) {
+              onCodeChange(value);
+            }
+          }}
+          options={{
+            minimap: { enabled: false },
+            fontSize: 12,
+            wordWrap: "on",
+            scrollBeyondLastLine: false,
+            automaticLayout: true,
+          }}
+        />
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/resume-editor/components/LaTeXSettings.tsx
+++ b/frontend/app/resume-editor/components/LaTeXSettings.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { LaTeXSettings } from "./types";
+
+interface LaTeXSettingsProps {
+  settings: LaTeXSettings;
+  onSettingsChange: (settings: Partial<LaTeXSettings>) => void;
+}
+
+export default function LaTeXSettingsPanel({ settings, onSettingsChange }: LaTeXSettingsProps) {
+  return (
+    <section className="bg-white/5 border border-white/10 rounded-xl p-5">
+      <h2 className="font-bold mb-4 text-sm tracking-wide">LATEX SETTINGS</h2>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="text-xs text-gray-400">Template</label>
+          <select
+            value={settings.selectedTemplate}
+            onChange={(e) =>
+              onSettingsChange({
+                selectedTemplate: e.target.value as
+                  | "classic"
+                  | "modern"
+                  | "creative"
+                  | "professional",
+              })
+            }
+            className="mt-1 w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
+          >
+            <option value="classic">Classic</option>
+            <option value="modern">Modern</option>
+            <option value="creative">Creative</option>
+            <option value="professional">Professional</option>
+          </select>
+        </div>
+        <div>
+          <label className="text-xs text-gray-400">Page Size</label>
+          <select
+            value={settings.pageSize}
+            onChange={(e) =>
+              onSettingsChange({ pageSize: e.target.value as "letter" | "a4" })
+            }
+            className="mt-1 w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
+          >
+            <option value="letter">Letter</option>
+            <option value="a4">A4</option>
+          </select>
+        </div>
+        <div>
+          <label className="text-xs text-gray-400">Font Family</label>
+          <select
+            value={settings.fontFamily}
+            onChange={(e) =>
+              onSettingsChange({
+                fontFamily: e.target.value as "serif" | "sans-serif" | "mono",
+              })
+            }
+            className="mt-1 w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
+          >
+            <option value="serif">Serif</option>
+            <option value="sans-serif">Sans Serif</option>
+            <option value="mono">Monospace</option>
+          </select>
+        </div>
+        <div>
+          <label className="text-xs text-gray-400">Colors</label>
+          <div className="flex gap-2 mt-1">
+            <input
+              type="color"
+              value={settings.primaryColor}
+              onChange={(e) => onSettingsChange({ primaryColor: e.target.value })}
+              className="w-full h-8 bg-black/40 border border-white/10 rounded cursor-pointer"
+              title="Primary Color"
+            />
+            <input
+              type="color"
+              value={settings.secondaryColor}
+              onChange={(e) => onSettingsChange({ secondaryColor: e.target.value })}
+              className="w-full h-8 bg-black/40 border border-white/10 rounded cursor-pointer"
+              title="Secondary Color"
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/resume-editor/components/PDFPreview.tsx
+++ b/frontend/app/resume-editor/components/PDFPreview.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { ZoomIn, ZoomOut, Download, FileText } from "lucide-react";
+
+interface PDFPreviewProps {
+  pdfUrl: string;
+  loading: boolean;
+  error: string | null;
+  wsConnected: boolean;
+  zoomLevel: number;
+  onZoomChange: (zoom: number) => void;
+  onRetry: () => void;
+}
+
+export default function PDFPreview({
+  pdfUrl,
+  loading,
+  error,
+  wsConnected,
+  zoomLevel,
+  onZoomChange,
+  onRetry,
+}: PDFPreviewProps) {
+  return (
+    <section className="bg-white/5 border border-white/10 rounded-xl p-5">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="font-bold text-sm tracking-wide">PDF PREVIEW</h2>
+        <div className="flex items-center gap-2">
+          <div
+            className={`text-xs px-2 py-1 rounded ${
+              wsConnected
+                ? "bg-green-500/20 text-green-400"
+                : "bg-red-500/20 text-red-400"
+            }`}
+          >
+            {wsConnected ? "● Connected" : "● Disconnected"}
+          </div>
+          <button
+            onClick={() => onZoomChange(Math.max(0.5, zoomLevel - 0.1))}
+            className="text-xs bg-white/10 hover:bg-white/20 text-white px-2 py-1 rounded"
+            disabled={zoomLevel <= 0.5}
+          >
+            <ZoomOut className="w-3 h-3" />
+          </button>
+          <span className="text-xs text-gray-400 min-w-[3rem] text-center">
+            {Math.round(zoomLevel * 100)}%
+          </span>
+          <button
+            onClick={() => onZoomChange(Math.min(2, zoomLevel + 0.1))}
+            className="text-xs bg-white/10 hover:bg-white/20 text-white px-2 py-1 rounded"
+            disabled={zoomLevel >= 2}
+          >
+            <ZoomIn className="w-3 h-3" />
+          </button>
+          {pdfUrl && (
+            <a
+              href={pdfUrl}
+              download="resume.pdf"
+              className="text-xs bg-white text-black font-semibold px-3 py-1.5 rounded-md hover:bg-gray-200 flex items-center gap-1"
+            >
+              <Download className="w-3 h-3" />
+              Download
+            </a>
+          )}
+        </div>
+      </div>
+
+      {/* PDF Viewer */}
+      <div className="bg-black/20 rounded-lg p-4 min-h-[600px] flex items-center justify-center">
+        {loading ? (
+          <div className="flex flex-col items-center gap-3">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
+            <p className="text-sm text-gray-400">Building your resume...</p>
+          </div>
+        ) : error ? (
+          <div className="text-center">
+            <div className="text-red-400 text-4xl mb-3">⚠</div>
+            <p className="text-sm text-red-400 mb-2">Connection Error</p>
+            <p className="text-xs text-gray-400">{error}</p>
+            <button
+              onClick={onRetry}
+              className="mt-3 text-xs bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600"
+            >
+              Retry
+            </button>
+          </div>
+        ) : pdfUrl ? (
+          <div
+            className="w-full h-full max-w-full overflow-auto"
+            style={{
+              transform: `scale(${zoomLevel})`,
+              transformOrigin: "top left",
+              width: `${100 / zoomLevel}%`,
+              height: `${100 / zoomLevel}%`,
+            }}
+          >
+            <iframe
+              src={`${pdfUrl}#toolbar=0&navpanes=0&scrollbar=0&view=FitH&zoom=page-width`}
+              className="w-full h-full min-h-[600px] border-0 rounded-md pdf-viewer"
+              title="Resume Preview"
+              style={{
+                pointerEvents: "auto",
+                overflow: "hidden",
+              }}
+            />
+
+            <style jsx>{`
+              .pdf-viewer {
+                filter: none;
+              }
+              .pdf-viewer::-webkit-scrollbar {
+                display: none;
+              }
+            `}</style>
+          </div>
+        ) : (
+          <div className="text-center">
+            <FileText className="w-12 h-12 text-gray-500 mx-auto mb-3" />
+            <p className="text-sm text-gray-400">
+              {wsConnected
+                ? "Click 'Manual Build' to generate your resume preview"
+                : "Connecting to LaTeX service..."}
+            </p>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/resume-editor/components/ResumeForm.tsx
+++ b/frontend/app/resume-editor/components/ResumeForm.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import { ResumeSection, ResumeFormData, CustomSection } from "./types";
+import BasicInfoSection from "./sections/BasicInfoSection";
+import SkillsSection from "./sections/SkillsSection";
+import ExperienceSection from "./sections/ExperienceSection";
+import EducationSection from "./sections/EducationSection";
+import ProjectsSection from "./sections/ProjectsSection";
+import CustomSectionComponent from "./sections/CustomSectionComponent";
+
+interface ResumeFormProps {
+  formData: ResumeFormData;
+  sections: ResumeSection[];
+  customSections: CustomSection[];
+  draggedSection: string | null;
+  onFormDataChange: (updates: Partial<ResumeFormData>) => void;
+  onSectionsChange: (sections: ResumeSection[]) => void;
+  onCustomSectionsChange: (customSections: CustomSection[]) => void;
+  onDragStart: (e: React.DragEvent, sectionId: string) => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent, targetSectionId: string) => void;
+  onDragEnd: () => void;
+}
+
+export default function ResumeForm({
+  formData,
+  sections,
+  customSections,
+  draggedSection,
+  onFormDataChange,
+  onSectionsChange,
+  onCustomSectionsChange,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
+}: ResumeFormProps) {
+  const addCustomSection = () => {
+    const newSection: ResumeSection = {
+      id: `custom-${Date.now()}`,
+      type: 'custom',
+      title: 'Custom Section',
+      order: sections.length
+    };
+    onSectionsChange([...sections, newSection]);
+    
+    const newCustomSection: CustomSection = {
+      id: newSection.id,
+      title: 'Custom Section',
+      content: ''
+    };
+    onCustomSectionsChange([...customSections, newCustomSection]);
+  };
+
+  const removeCustomSection = (sectionId: string) => {
+    onSectionsChange(sections.filter(s => s.id !== sectionId));
+    onCustomSectionsChange(customSections.filter(s => s.id !== sectionId));
+  };
+
+  const updateCustomSection = (sectionId: string, updates: Partial<CustomSection>) => {
+    onCustomSectionsChange(customSections.map(s => 
+      s.id === sectionId ? { ...s, ...updates } : s
+    ));
+  };
+
+  const renderSection = (section: ResumeSection) => {
+    const sectionClasses = `bg-white/5 border border-white/10 rounded-xl p-5 ${
+      draggedSection === section.id ? 'opacity-50' : ''
+    }`;
+
+    const handleSectionDragStart = (e: React.DragEvent) => onDragStart(e, section.id);
+    const handleSectionDrop = (e: React.DragEvent) => onDrop(e, section.id);
+
+    switch (section.type) {
+      case 'basic':
+        return (
+          <BasicInfoSection
+            key={section.id}
+            section={section}
+            formData={formData}
+            onFormDataChange={onFormDataChange}
+          />
+        );
+
+      case 'skills':
+        return (
+          <SkillsSection
+            key={section.id}
+            section={section}
+            skills={formData.skills}
+            onSkillsChange={(skills) => onFormDataChange({ skills })}
+            draggedSection={draggedSection}
+            onDragStart={handleSectionDragStart}
+            onDragOver={onDragOver}
+            onDrop={handleSectionDrop}
+            onDragEnd={onDragEnd}
+          />
+        );
+
+      case 'experience':
+        return (
+          <ExperienceSection
+            key={section.id}
+            section={section}
+            experiences={formData.experiences}
+            onExperiencesChange={(experiences) => onFormDataChange({ experiences })}
+            draggedSection={draggedSection}
+            onDragStart={handleSectionDragStart}
+            onDragOver={onDragOver}
+            onDrop={handleSectionDrop}
+            onDragEnd={onDragEnd}
+          />
+        );
+
+      case 'education':
+        return (
+          <EducationSection
+            key={section.id}
+            section={section}
+            educations={formData.educations}
+            onEducationsChange={(educations) => onFormDataChange({ educations })}
+            draggedSection={draggedSection}
+            onDragStart={handleSectionDragStart}
+            onDragOver={onDragOver}
+            onDrop={handleSectionDrop}
+            onDragEnd={onDragEnd}
+          />
+        );
+
+      case 'projects':
+        return (
+          <ProjectsSection
+            key={section.id}
+            section={section}
+            projects={formData.projects}
+            onProjectsChange={(projects) => onFormDataChange({ projects })}
+            draggedSection={draggedSection}
+            onDragStart={handleSectionDragStart}
+            onDragOver={onDragOver}
+            onDrop={handleSectionDrop}
+            onDragEnd={onDragEnd}
+          />
+        );
+
+      case 'custom':
+        const customSection = customSections.find(cs => cs.id === section.id);
+        return (
+          <CustomSectionComponent
+            key={section.id}
+            section={section}
+            customSection={customSection}
+            draggedSection={draggedSection}
+            onDragStart={handleSectionDragStart}
+            onDragOver={onDragOver}
+            onDrop={handleSectionDrop}
+            onDragEnd={onDragEnd}
+            onUpdateCustomSection={updateCustomSection}
+            onRemoveCustomSection={removeCustomSection}
+          />
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <>
+      {/* Dynamic Draggable Sections */}
+      {sections
+        .sort((a, b) => a.order - b.order)
+        .map(section => renderSection(section))}
+      
+      {/* Add Custom Section Button */}
+      <section className="bg-white/5 border border-white/10 rounded-xl p-5">
+        <button
+          onClick={addCustomSection}
+          className="w-full flex items-center justify-center gap-2 py-4 border-2 border-dashed border-white/20 rounded-lg hover:border-white/40 transition-colors"
+        >
+          <Plus className="w-5 h-5 text-white/60" />
+          <span className="text-sm text-white/60 font-medium">Add Custom Section</span>
+        </button>
+      </section>
+    </>
+  );
+}

--- a/frontend/app/resume-editor/components/ViewTabs.tsx
+++ b/frontend/app/resume-editor/components/ViewTabs.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Eye, Code } from "lucide-react";
+
+interface ViewTabsProps {
+  activeTab: "form" | "latex";
+  autoRender: boolean;
+  loading: boolean;
+  onTabSwitch: (tab: "form" | "latex") => void;
+  onAutoRenderChange: (autoRender: boolean) => void;
+  onManualBuild: () => void;
+}
+
+export default function ViewTabs({
+  activeTab,
+  autoRender,
+  loading,
+  onTabSwitch,
+  onAutoRenderChange,
+  onManualBuild,
+}: ViewTabsProps) {
+  return (
+    <section className="bg-white/5 border border-white/10 rounded-xl p-5">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="font-bold text-sm tracking-wide">VIEW MODE</h2>
+        <div className="flex items-center gap-2">
+          <label className="text-xs text-gray-400 flex items-center gap-1">
+            <input
+              type="checkbox"
+              checked={autoRender}
+              onChange={(e) => onAutoRenderChange(e.target.checked)}
+              className="w-3 h-3"
+            />
+            Auto Render
+          </label>
+          <button
+            onClick={onManualBuild}
+            disabled={loading}
+            className="text-xs bg-white text-black font-semibold px-3 py-1.5 rounded-md hover:bg-gray-200 disabled:opacity-50"
+          >
+            {loading ? "Building..." : "Build"}
+          </button>
+        </div>
+      </div>
+      <div className="flex gap-2">
+        <button
+          onClick={() => onTabSwitch("form")}
+          className={`px-4 py-2 text-xs font-medium rounded-md transition-colors ${
+            activeTab === "form"
+              ? "bg-white text-black"
+              : "bg-white/10 text-gray-300 hover:bg-white/20"
+          }`}
+        >
+          <Eye className="w-3 h-3 inline mr-1" />
+          Form Editor
+        </button>
+        <button
+          onClick={() => onTabSwitch("latex")}
+          className={`px-4 py-2 text-xs font-medium rounded-md transition-colors ${
+            activeTab === "latex"
+              ? "bg-white text-black"
+              : "bg-white/10 text-gray-300 hover:bg-white/20"
+          }`}
+        >
+          <Code className="w-3 h-3 inline mr-1" />
+          LaTeX Code
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/resume-editor/components/sections/BasicInfoSection.tsx
+++ b/frontend/app/resume-editor/components/sections/BasicInfoSection.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { ResumeSection, ResumeFormData, Link } from "../types";
+
+interface BasicInfoSectionProps {
+  section: ResumeSection;
+  formData: ResumeFormData;
+  onFormDataChange: (updates: Partial<ResumeFormData>) => void;
+}
+
+export default function BasicInfoSection({
+  section,
+  formData,
+  onFormDataChange,
+}: BasicInfoSectionProps) {
+  const { fullName, title, summary, email, phone, location, website, links } = formData;
+
+  const addLink = () => {
+    const newLinks = [...links, { id: Date.now().toString(), label: "", url: "" }];
+    onFormDataChange({ links: newLinks });
+  };
+
+  const updateLink = (id: string, updates: Partial<Link>) => {
+    const updatedLinks = links.map((link) => 
+      link.id === id ? { ...link, ...updates } : link
+    );
+    onFormDataChange({ links: updatedLinks });
+  };
+
+  const removeLink = (id: string) => {
+    const filteredLinks = links.filter((link) => link.id !== id);
+    onFormDataChange({ links: filteredLinks });
+  };
+
+  return (
+    <section className="bg-white/5 border border-white/10 rounded-xl p-5">
+      <div className="flex items-center mb-4">
+        <h2 className="font-bold text-sm tracking-wide">
+          {section.title.toUpperCase()}
+        </h2>
+      </div>
+      <div className="grid md:grid-cols-2 gap-4">
+        <div>
+          <label className="text-xs text-gray-400">Full Name</label>
+          <input
+            value={fullName}
+            onChange={(e) => onFormDataChange({ fullName: e.target.value })}
+            className="mt-1 w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
+            placeholder="John Doe"
+          />
+        </div>
+        <div>
+          <label className="text-xs text-gray-400">Title</label>
+          <input
+            value={title}
+            onChange={(e) => onFormDataChange({ title: e.target.value })}
+            className="mt-1 w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
+            placeholder="Frontend Engineer"
+          />
+        </div>
+      </div>
+      <div className="mt-4">
+        <label className="text-xs text-gray-400">Professional Summary</label>
+        <textarea
+          value={summary}
+          onChange={(e) => onFormDataChange({ summary: e.target.value })}
+          rows={4}
+          className="mt-1 w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm resize-y outline-none focus:border-white/30"
+          placeholder="2–3 line impactful summary..."
+        />
+      </div>
+      <div className="mt-4 grid md:grid-cols-2 gap-4">
+        <div>
+          <label className="text-xs text-gray-400">Email</label>
+          <input
+            value={email}
+            onChange={(e) => onFormDataChange({ email: e.target.value })}
+            type="email"
+            placeholder="john.doe@email.com"
+            className="mt-1 w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
+          />
+        </div>
+        <div>
+          <label className="text-xs text-gray-400">Phone</label>
+          <input
+            value={phone}
+            onChange={(e) => onFormDataChange({ phone: e.target.value })}
+            placeholder="+91 1234 5678 90"
+            className="mt-1 w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
+          />
+        </div>
+        <div>
+          <label className="text-xs text-gray-400">Location</label>
+          <input
+            value={location}
+            onChange={(e) => onFormDataChange({ location: e.target.value })}
+            placeholder="City, Country / Remote"
+            className="mt-1 w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
+          />
+        </div>
+        <div>
+          <label className="text-xs text-gray-400">Website / Primary Link</label>
+          <input
+            value={website}
+            onChange={(e) => onFormDataChange({ website: e.target.value })}
+            placeholder="https://linkedin.com/in/username"
+            className="mt-1 w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
+          />
+        </div>
+      </div>
+
+      {/* Additional links */}
+      <div className="mt-6">
+        <div className="flex items-center justify-between mb-2">
+          <label className="text-xs text-gray-400">Additional Links</label>
+          <button
+            type="button"
+            onClick={addLink}
+            className="text-[11px] px-2 py-1 rounded bg-white text-black font-semibold hover:bg-gray-200"
+          >
+            + Add
+          </button>
+        </div>
+        {links.length === 0 && (
+          <p className="text-[11px] text-gray-500">
+            (Optional) Add portfolio, GitHub, publications, etc.
+          </p>
+        )}
+        <div className="space-y-2">
+          {links.map((l) => (
+            <div key={l.id} className="flex gap-2">
+              <input
+                value={l.label}
+                onChange={(e) => updateLink(l.id, { label: e.target.value })}
+                placeholder="Label (e.g. GitHub)"
+                className="flex-1 bg-black/40 border border-white/10 rounded-md px-2 py-1 text-xs outline-none focus:border-white/30"
+              />
+              <input
+                value={l.url}
+                onChange={(e) => updateLink(l.id, { url: e.target.value })}
+                placeholder="https://..."
+                className="flex-[1.4] bg-black/40 border border-white/10 rounded-md px-2 py-1 text-xs outline-none focus:border-white/30"
+              />
+              <button
+                onClick={() => removeLink(l.id)}
+                className="text-gray-400 hover:text-red-400 text-xs px-2"
+                title="Remove"
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/resume-editor/components/sections/CustomSectionComponent.tsx
+++ b/frontend/app/resume-editor/components/sections/CustomSectionComponent.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { GripVertical, X } from "lucide-react";
+import { ResumeSection, CustomSection } from "../types";
+
+interface CustomSectionComponentProps {
+  section: ResumeSection;
+  customSection: CustomSection | undefined;
+  draggedSection: string | null;
+  onDragStart: (e: React.DragEvent) => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent) => void;
+  onDragEnd: () => void;
+  onUpdateCustomSection: (sectionId: string, updates: Partial<CustomSection>) => void;
+  onRemoveCustomSection: (sectionId: string) => void;
+}
+
+export default function CustomSectionComponent({
+  section,
+  customSection,
+  draggedSection,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
+  onUpdateCustomSection,
+  onRemoveCustomSection,
+}: CustomSectionComponentProps) {
+  const sectionClasses = `bg-white/5 border border-white/10 rounded-xl p-5 ${
+    draggedSection === section.id ? 'opacity-50' : ''
+  }`;
+
+  return (
+    <section 
+      className={sectionClasses}
+      draggable
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onDragEnd={onDragEnd}
+    >
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center">
+          <GripVertical className="w-4 h-4 text-gray-400 cursor-move mr-2" />
+          <input
+            value={customSection?.title || ''}
+            onChange={(e) => onUpdateCustomSection(section.id, { title: e.target.value })}
+            className="font-bold text-sm tracking-wide bg-transparent border-b border-white/20 outline-none focus:border-white/50"
+            placeholder="SECTION TITLE"
+          />
+        </div>
+        <button
+          onClick={() => onRemoveCustomSection(section.id)}
+          className="text-[11px] px-2 py-1 rounded bg-red-500 text-white hover:bg-red-600"
+        >
+          <X className="w-3 h-3" />
+        </button>
+      </div>
+      <textarea
+        value={customSection?.content || ''}
+        onChange={(e) => onUpdateCustomSection(section.id, { content: e.target.value })}
+        placeholder="Enter section content..."
+        rows={6}
+        className="w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm resize-y outline-none focus:border-white/30"
+      />
+    </section>
+  );
+}

--- a/frontend/app/resume-editor/components/sections/EducationSection.tsx
+++ b/frontend/app/resume-editor/components/sections/EducationSection.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { GripVertical } from "lucide-react";
+import { ResumeSection, Education } from "../types";
+
+interface EducationSectionProps {
+  section: ResumeSection;
+  educations: Education[];
+  onEducationsChange: (educations: Education[]) => void;
+  draggedSection: string | null;
+  onDragStart: (e: React.DragEvent) => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent) => void;
+  onDragEnd: () => void;
+}
+
+export default function EducationSection({
+  section,
+  educations,
+  onEducationsChange,
+  draggedSection,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
+}: EducationSectionProps) {
+  const sectionClasses = `bg-white/5 border border-white/10 rounded-xl p-5 ${
+    draggedSection === section.id ? 'opacity-50' : ''
+  }`;
+
+  const addEducation = () => {
+    const newEducations = [
+      ...educations,
+      {
+        id: Date.now().toString(),
+        degree: "",
+        institution: "",
+        year: "",
+        gpa: "",
+      },
+    ];
+    onEducationsChange(newEducations);
+  };
+
+  const updateEducation = (id: string, updates: Partial<Education>) => {
+    const updatedEducations = educations.map((edu) => 
+      edu.id === id ? { ...edu, ...updates } : edu
+    );
+    onEducationsChange(updatedEducations);
+  };
+
+  const removeEducation = (id: string) => {
+    const filteredEducations = educations.filter((edu) => edu.id !== id);
+    onEducationsChange(filteredEducations);
+  };
+
+  return (
+    <section 
+      className={sectionClasses}
+      draggable
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onDragEnd={onDragEnd}
+    >
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center">
+          <GripVertical className="w-4 h-4 text-gray-400 cursor-move mr-2" />
+          <h2 className="font-bold text-sm tracking-wide">
+            {section.title.toUpperCase()}
+          </h2>
+        </div>
+        <button
+          type="button"
+          onClick={addEducation}
+          className="text-[11px] px-2 py-1 rounded bg-white text-black font-semibold hover:bg-gray-200"
+        >
+          + Add
+        </button>
+      </div>
+      <div className="space-y-4">
+        {educations.map((edu) => (
+          <div key={edu.id} className="bg-black/20 rounded-lg p-4">
+            <div className="flex justify-end mb-2">
+              <button
+                onClick={() => removeEducation(edu.id)}
+                className="text-gray-400 hover:text-red-400 text-xs"
+                title="Remove Education"
+              >
+                × Remove
+              </button>
+            </div>
+            <div className="grid md:grid-cols-2 gap-3 mb-3">
+              <input
+                value={edu.degree}
+                onChange={(e) => updateEducation(edu.id, { degree: e.target.value })}
+                placeholder="Degree"
+                className="bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
+              />
+              <input
+                value={edu.institution}
+                onChange={(e) => updateEducation(edu.id, { institution: e.target.value })}
+                placeholder="Institution"
+                className="bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
+              />
+            </div>
+            <div className="grid md:grid-cols-2 gap-3">
+              <input
+                value={edu.year}
+                onChange={(e) => updateEducation(edu.id, { year: e.target.value })}
+                placeholder="Year (e.g. 2023)"
+                className="bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
+              />
+              <input
+                value={edu.gpa}
+                onChange={(e) => updateEducation(edu.id, { gpa: e.target.value })}
+                placeholder="GPA (optional)"
+                className="bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/resume-editor/components/sections/ExperienceSection.tsx
+++ b/frontend/app/resume-editor/components/sections/ExperienceSection.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { GripVertical } from "lucide-react";
+import { ResumeSection, Experience } from "../types";
+
+interface ExperienceSectionProps {
+  section: ResumeSection;
+  experiences: Experience[];
+  onExperiencesChange: (experiences: Experience[]) => void;
+  draggedSection: string | null;
+  onDragStart: (e: React.DragEvent) => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent) => void;
+  onDragEnd: () => void;
+}
+
+export default function ExperienceSection({
+  section,
+  experiences,
+  onExperiencesChange,
+  draggedSection,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
+}: ExperienceSectionProps) {
+  const sectionClasses = `bg-white/5 border border-white/10 rounded-xl p-5 ${
+    draggedSection === section.id ? 'opacity-50' : ''
+  }`;
+
+  const addExperience = () => {
+    const newExperiences = [
+      ...experiences,
+      {
+        id: Date.now().toString(),
+        title: "",
+        company: "",
+        startDate: "",
+        endDate: "",
+        description: "",
+      },
+    ];
+    onExperiencesChange(newExperiences);
+  };
+
+  const updateExperience = (id: string, updates: Partial<Experience>) => {
+    const updatedExperiences = experiences.map((exp) => 
+      exp.id === id ? { ...exp, ...updates } : exp
+    );
+    onExperiencesChange(updatedExperiences);
+  };
+
+  const removeExperience = (id: string) => {
+    const filteredExperiences = experiences.filter((exp) => exp.id !== id);
+    onExperiencesChange(filteredExperiences);
+  };
+
+  return (
+    <section 
+      className={sectionClasses}
+      draggable
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onDragEnd={onDragEnd}
+    >
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center">
+          <GripVertical className="w-4 h-4 text-gray-400 cursor-move mr-2" />
+          <h2 className="font-bold text-sm tracking-wide">
+            {section.title.toUpperCase()}
+          </h2>
+        </div>
+        <button
+          type="button"
+          onClick={addExperience}
+          className="text-[11px] px-2 py-1 rounded bg-white text-black font-semibold hover:bg-gray-200"
+        >
+          + Add
+        </button>
+      </div>
+      <div className="space-y-4">
+        {experiences.map((exp) => (
+          <div key={exp.id} className="bg-black/20 rounded-lg p-4">
+            <div className="flex justify-end mb-2">
+              <button
+                onClick={() => removeExperience(exp.id)}
+                className="text-gray-400 hover:text-red-400 text-xs"
+                title="Remove Experience"
+              >
+                × Remove
+              </button>
+            </div>
+            <div className="grid md:grid-cols-2 gap-3 mb-3">
+              <input
+                value={exp.title}
+                onChange={(e) => updateExperience(exp.id, { title: e.target.value })}
+                placeholder="Job Title"
+                className="bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
+              />
+              <input
+                value={exp.company}
+                onChange={(e) => updateExperience(exp.id, { company: e.target.value })}
+                placeholder="Company"
+                className="bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
+              />
+            </div>
+            <div className="grid md:grid-cols-2 gap-3 mb-3">
+              <input
+                value={exp.startDate}
+                onChange={(e) => updateExperience(exp.id, { startDate: e.target.value })}
+                placeholder="Start Date (e.g. Jan 2023)"
+                className="bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
+              />
+              <input
+                value={exp.endDate}
+                onChange={(e) => updateExperience(exp.id, { endDate: e.target.value })}
+                placeholder="End Date (or 'Present')"
+                className="bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
+              />
+            </div>
+            <textarea
+              value={exp.description}
+              onChange={(e) => updateExperience(exp.id, { description: e.target.value })}
+              placeholder="Key achievements and responsibilities..."
+              rows={3}
+              className="w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm resize-y outline-none focus:border-white/30"
+            />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/resume-editor/components/sections/ProjectsSection.tsx
+++ b/frontend/app/resume-editor/components/sections/ProjectsSection.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { GripVertical } from "lucide-react";
+import { ResumeSection, Project } from "../types";
+
+interface ProjectsSectionProps {
+  section: ResumeSection;
+  projects: Project[];
+  onProjectsChange: (projects: Project[]) => void;
+  draggedSection: string | null;
+  onDragStart: (e: React.DragEvent) => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent) => void;
+  onDragEnd: () => void;
+}
+
+export default function ProjectsSection({
+  section,
+  projects,
+  onProjectsChange,
+  draggedSection,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
+}: ProjectsSectionProps) {
+  const sectionClasses = `bg-white/5 border border-white/10 rounded-xl p-5 ${
+    draggedSection === section.id ? 'opacity-50' : ''
+  }`;
+
+  const addProject = () => {
+    const newProjects = [
+      ...projects,
+      {
+        id: Date.now().toString(),
+        name: "",
+        technologies: "",
+        link: "",
+        description: "",
+      },
+    ];
+    onProjectsChange(newProjects);
+  };
+
+  const updateProject = (id: string, updates: Partial<Project>) => {
+    const updatedProjects = projects.map((proj) => 
+      proj.id === id ? { ...proj, ...updates } : proj
+    );
+    onProjectsChange(updatedProjects);
+  };
+
+  const removeProject = (id: string) => {
+    const filteredProjects = projects.filter((proj) => proj.id !== id);
+    onProjectsChange(filteredProjects);
+  };
+
+  return (
+    <section 
+      className={sectionClasses}
+      draggable
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onDragEnd={onDragEnd}
+    >
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center">
+          <GripVertical className="w-4 h-4 text-gray-400 cursor-move mr-2" />
+          <h2 className="font-bold text-sm tracking-wide">
+            {section.title.toUpperCase()}
+          </h2>
+        </div>
+        <button
+          type="button"
+          onClick={addProject}
+          className="text-[11px] px-2 py-1 rounded bg-white text-black font-semibold hover:bg-gray-200"
+        >
+          + Add
+        </button>
+      </div>
+      <div className="space-y-4">
+        {projects.map((proj) => (
+          <div key={proj.id} className="bg-black/20 rounded-lg p-4">
+            <div className="flex justify-end mb-2">
+              <button
+                onClick={() => removeProject(proj.id)}
+                className="text-gray-400 hover:text-red-400 text-xs"
+                title="Remove Project"
+              >
+                × Remove
+              </button>
+            </div>
+            <div className="mb-3">
+              <input
+                value={proj.name}
+                onChange={(e) => updateProject(proj.id, { name: e.target.value })}
+                placeholder="Project Name"
+                className="w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
+              />
+            </div>
+            <div className="grid md:grid-cols-2 gap-3 mb-3">
+              <input
+                value={proj.technologies}
+                onChange={(e) => updateProject(proj.id, { technologies: e.target.value })}
+                placeholder="Technologies (e.g. React, Node.js)"
+                className="bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
+              />
+              <input
+                value={proj.link}
+                onChange={(e) => updateProject(proj.id, { link: e.target.value })}
+                placeholder="Link (optional)"
+                className="bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
+              />
+            </div>
+            <textarea
+              value={proj.description}
+              onChange={(e) => updateProject(proj.id, { description: e.target.value })}
+              placeholder="Project description and achievements..."
+              rows={3}
+              className="w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm resize-y outline-none focus:border-white/30"
+            />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/resume-editor/components/sections/SkillsSection.tsx
+++ b/frontend/app/resume-editor/components/sections/SkillsSection.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { GripVertical } from "lucide-react";
+import { ResumeSection } from "../types";
+
+interface SkillsSectionProps {
+  section: ResumeSection;
+  skills: string;
+  onSkillsChange: (skills: string) => void;
+  draggedSection: string | null;
+  onDragStart: (e: React.DragEvent) => void;
+  onDragOver: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent) => void;
+  onDragEnd: () => void;
+}
+
+export default function SkillsSection({
+  section,
+  skills,
+  onSkillsChange,
+  draggedSection,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
+}: SkillsSectionProps) {
+  const sectionClasses = `bg-white/5 border border-white/10 rounded-xl p-5 ${
+    draggedSection === section.id ? 'opacity-50' : ''
+  }`;
+
+  return (
+    <section 
+      className={sectionClasses}
+      draggable
+      onDragStart={onDragStart}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      onDragEnd={onDragEnd}
+    >
+      <div className="flex items-center mb-4">
+        <GripVertical className="w-4 h-4 text-gray-400 cursor-move mr-2" />
+        <h2 className="font-bold text-sm tracking-wide">
+          {section.title.toUpperCase()}
+        </h2>
+      </div>
+      <textarea
+        value={skills}
+        onChange={(e) => onSkillsChange(e.target.value)}
+        placeholder="List your technical skills, programming languages, frameworks, tools, etc."
+        rows={4}
+        className="w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm resize-y outline-none focus:border-white/30"
+      />
+    </section>
+  );
+}

--- a/frontend/app/resume-editor/components/types.ts
+++ b/frontend/app/resume-editor/components/types.ts
@@ -1,0 +1,68 @@
+// Resume Editor Types
+export interface Link {
+  id: string;
+  label: string;
+  url: string;
+}
+
+export interface Experience {
+  id: string;
+  title: string;
+  company: string;
+  startDate: string;
+  endDate: string;
+  description: string;
+}
+
+export interface Education {
+  id: string;
+  degree: string;
+  institution: string;
+  year: string;
+  gpa: string;
+}
+
+export interface Project {
+  id: string;
+  name: string;
+  technologies: string;
+  link: string;
+  description: string;
+}
+
+export interface CustomSection {
+  id: string;
+  title: string;
+  content: string;
+}
+
+export interface ResumeSection {
+  id: string;
+  type: 'basic' | 'skills' | 'experience' | 'education' | 'projects' | 'custom';
+  title: string;
+  order: number;
+}
+
+export interface ResumeFormData {
+  fullName: string;
+  title: string;
+  summary: string;
+  skills: string;
+  email: string;
+  phone: string;
+  location: string;
+  website: string;
+  links: Link[];
+  experiences: Experience[];
+  educations: Education[];
+  projects: Project[];
+  customSections: CustomSection[];
+}
+
+export interface LaTeXSettings {
+  selectedTemplate: "classic" | "modern" | "creative" | "professional";
+  pageSize: "letter" | "a4";
+  fontFamily: "serif" | "sans-serif" | "mono";
+  primaryColor: string;
+  secondaryColor: string;
+}

--- a/frontend/app/resume-editor/page.tsx
+++ b/frontend/app/resume-editor/page.tsx
@@ -1,246 +1,412 @@
 "use client";
 
-import React, { useState } from "react";
-import Sidebar from "../../components/main/sidebar";
-import Header from "@/components/main/header";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { SignedIn, SignedOut, RedirectToSignIn } from "@clerk/nextjs";
-import { Bot, Plus, Trash2 } from "lucide-react";
+import Sidebar from "../../components/main/sidebar";
+import Header from "../../components/main/header";
 import FooterSection from "@/components/footer";
+import { generateResumeTex } from "@/lib/latexTemplate";
 
-type SectionEntry = {
-  id: string;
-  position: string;
-  organization: string;
-  start: string;
-  end: string;
-  bullets: string[];
-  linkLabel?: string;
-  linkUrl?: string;
-};
-type Section = {
-  id: string;
-  name: string;
-  entries: SectionEntry[];
-};
+// Import components
+import ViewTabs from "./components/ViewTabs";
+import LaTeXSettingsPanel from "./components/LaTeXSettings";
+import LaTeXEditor from "./components/LaTeXEditor";
+import PDFPreview from "./components/PDFPreview";
+import ResumeForm from "./components/ResumeForm";
 
-export default function ResumeEditorPage() {
+// Import types
+import { 
+  ResumeFormData, 
+  LaTeXSettings, 
+  ResumeSection, 
+  CustomSection 
+} from "./components/types";
+
+export default function ResumeEditor() {
+  // Sidebar state
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
-  const [fullName, setFullName] = useState("");
-  const [title, setTitle] = useState("");
-  const [summary, setSummary] = useState("");
-  const [skills, setSkills] = useState<string>("React, TypeScript, Next.js");
-  const [sections, setSections] = useState<Section[]>([
-    {
-      id: crypto.randomUUID(),
-      name: "Experience",
-      entries: [
-        {
-          id: crypto.randomUUID(),
-          position: "Frontend Engineer",
-          organization: "Your Company Here",
-          start: "20XX-01",
-          end: "Present",
-          bullets: ["Built reusable UI", "Improved performance by 25%"],
-          linkLabel: "Portfolio",
-          linkUrl: "", // cleared to avoid accidental leftover link
-        },
-      ],
-    },
-    {
-      id: crypto.randomUUID(),
-      name: "Education",
-      entries: [
-        {
-          id: crypto.randomUUID(),
-          position: "B.S. Computer Science",
-          organization: "University Name",
-          start: "20XX-09",
-          end: "20XX-06",
-          bullets: [
-            "Graduated with Honors (GPA 9.0/10.0)",
-            "Relevant Coursework: Algorithms, Systems, Databases",
-          ],
-          linkLabel: "Transcript",
-          linkUrl: "",
-        },
-      ],
-    },
-    {
-      id: crypto.randomUUID(),
-      name: "Misc",
-      entries: [
-        {
-          id: crypto.randomUUID(),
-          position: "Open Source Contributor",
-          organization: "GitHub",
-          start: "20XX-04",
-          end: "Present",
-          bullets: [
-            "Contributed to 5+ popular React libraries",
-            "Maintainer of a small utility with 1k+ monthly downloads",
-          ],
-          linkLabel: "GitHub Profile",
-          linkUrl: "", // left empty to not be left in accidentsally
-        },
-      ],
-    },
+
+  // View state
+  const [activeTab, setActiveTab] = useState<"form" | "latex">("form");
+
+  // LaTeX integration state
+  const [latexCode, setLatexCode] = useState("");
+  const [pdfUrl, setPdfUrl] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [zoomLevel, setZoomLevel] = useState(1);
+  const [autoRender, setAutoRender] = useState(true);
+  const [wsConnected, setWsConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // LaTeX settings
+  const [latexSettings, setLatexSettings] = useState<LaTeXSettings>({
+    selectedTemplate: "modern",
+    pageSize: "letter",
+    fontFamily: "sans-serif",
+    primaryColor: "#2563eb",
+    secondaryColor: "#1e40af",
+  });
+
+  // Form data
+  const [formData, setFormData] = useState<ResumeFormData>({
+    fullName: "John Doe",
+    title: "Full Stack Developer",
+    summary: "Experienced developer with expertise in React, Node.js, and modern web technologies.",
+    skills: "React, TypeScript, Node.js, Python, AWS",
+    email: "john.doe@email.com",
+    phone: "+1 (555) 123-4567",
+    location: "San Francisco, CA",
+    website: "https://linkedin.com/in/johndoe",
+    links: [],
+    experiences: [],
+    educations: [],
+    projects: [],
+    customSections: [],
+  });
+
+  // Section order and visibility
+  const [sections, setSections] = useState<ResumeSection[]>([
+    { id: 'basic', type: 'basic', title: 'Basic Info', order: 0 },
+    { id: 'skills', type: 'skills', title: 'Skills', order: 1 },
+    { id: 'experience', type: 'experience', title: 'Work Experience', order: 2 },
+    { id: 'education', type: 'education', title: 'Education', order: 3 },
+    { id: 'projects', type: 'projects', title: 'Projects', order: 4 },
   ]);
-  const [email, setEmail] = useState("");
-  const [phone, setPhone] = useState("");
-  const [location, setLocation] = useState("");
-  const [website, setWebsite] = useState("");
-  const [links, setLinks] = useState<
-    { id: string; label: string; url: string }[]
-  >([]);
 
-  const addSection = () =>
-    setSections((prev) => [
-      ...prev,
-      {
-        id: crypto.randomUUID(),
-        name: "New Section",
-        entries: [
-          {
-            id: crypto.randomUUID(),
-            position: "",
-            organization: "",
-            start: "",
-            end: "",
-            bullets: [""],
-            linkLabel: "",
-            linkUrl: "",
-          },
-        ],
-      },
-    ]);
+  const [customSections, setCustomSections] = useState<CustomSection[]>([]);
 
-  const updateSection = (id: string, patch: Partial<Section>) =>
-    setSections((prev) =>
-      prev.map((s) => (s.id === id ? { ...s, ...patch } : s))
-    );
+  // Drag and drop state
+  const [draggedSection, setDraggedSection] = useState<string | null>(null);
 
-  const removeSection = (id: string) =>
-    setSections((prev) => prev.filter((s) => s.id !== id));
+  // WebSocket connection
+  const wsRef = useRef<WebSocket | null>(null);
+  const pdfUrlRef = useRef<string | null>(null);
 
-  const addEntry = (sectionId: string) =>
-    setSections((prev) =>
-      prev.map((s) =>
-        s.id === sectionId
-          ? {
-              ...s,
-              entries: [
-                ...s.entries,
-                {
-                  id: crypto.randomUUID(),
-                  position: "",
-                  organization: "",
-                  start: "",
-                  end: "",
-                  bullets: [""],
-                  linkLabel: "",
-                  linkUrl: "",
-                },
-              ],
+  // WebSocket setup
+  useEffect(() => {
+    const connectWebSocket = () => {
+      const ws = new WebSocket("wss://ayush-003-latexwebsocket.hf.space");
+
+      ws.onopen = () => {
+        wsRef.current = ws;
+        setWsConnected(true);
+        setError(null);
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data);
+
+          if (data.type === "progress") {
+            setLoading(true);
+          } else if (data.type === "pdf") {
+            // Handle base64 PDF data
+            const arr = Uint8Array.from(atob(data.base64), (c) =>
+              c.charCodeAt(0)
+            );
+            const blob = new Blob([arr], { type: "application/pdf" });
+            const url = URL.createObjectURL(blob);
+
+            // Clean up previous URL
+            if (pdfUrlRef.current) {
+              URL.revokeObjectURL(pdfUrlRef.current);
             }
-          : s
-      )
-    );
 
-  const updateEntry = (
-    sectionId: string,
-    entryId: string,
-    patch: Partial<SectionEntry>
-  ) =>
-    setSections((prev) =>
-      prev.map((s) =>
-        s.id === sectionId
-          ? {
-              ...s,
-              entries: s.entries.map((e) =>
-                e.id === entryId ? { ...e, ...patch } : e
-              ),
-            }
-          : s
-      )
-    );
+            pdfUrlRef.current = url;
+            setPdfUrl(url);
+            setLoading(false);
+            setError(null);
+          } else if (data.type === "pdf_ready") {
+            setPdfUrl(data.pdf_url);
+            setLoading(false);
+            setError(null);
+          } else if (data.type === "error") {
+            setLoading(false);
+            setError(`Compilation error: ${data.message}`);
+          }
+        } catch (error) {
+          console.error("Error parsing WebSocket message:", error);
+          setLoading(false);
+          setError("Error parsing response from server");
+        }
+      };
 
-  const removeEntry = (sectionId: string, entryId: string) =>
-    setSections((prev) =>
-      prev.map((s) =>
-        s.id === sectionId
-          ? { ...s, entries: s.entries.filter((e) => e.id !== entryId) }
-          : s
-      )
-    );
+      ws.onclose = (event) => {
+        wsRef.current = null;
+        setWsConnected(false);
+        setError(`Connection lost: ${event.reason || "Unknown reason"}`);
+        // Reconnect after 3 seconds
+        setTimeout(connectWebSocket, 3000);
+      };
 
-  const updateBullet = (
-    sectionId: string,
-    entryId: string,
-    idx: number,
-    value: string
-  ) =>
-    setSections((prev) =>
-      prev.map((s) =>
-        s.id === sectionId
-          ? {
-              ...s,
-              entries: s.entries.map((e) =>
-                e.id === entryId
-                  ? {
-                      ...e,
-                      bullets: e.bullets.map((b, i) => (i === idx ? value : b)),
-                    }
-                  : e
-              ),
-            }
-          : s
-      )
-    );
+      ws.onerror = (error) => {
+        console.error("WebSocket error:", error);
+        setLoading(false);
+        setWsConnected(false);
+        setError("WebSocket connection failed");
+      };
+    };
 
-  const addBullet = (sectionId: string, entryId: string) =>
-    setSections((prev) =>
-      prev.map((s) =>
-        s.id === sectionId
-          ? {
-              ...s,
-              entries: s.entries.map((e) =>
-                e.id === entryId ? { ...e, bullets: [...e.bullets, ""] } : e
-              ),
-            }
-          : s
-      )
-    );
+    connectWebSocket();
 
-  const removeBullet = (sectionId: string, entryId: string, idx: number) =>
-    setSections((prev) =>
-      prev.map((s) =>
-        s.id === sectionId
-          ? {
-              ...s,
-              entries: s.entries.map((e) =>
-                e.id === entryId
-                  ? { ...e, bullets: e.bullets.filter((_, i) => i !== idx) }
-                  : e
-              ),
-            }
-          : s
-      )
-    );
+    return () => {
+      if (wsRef.current) {
+        wsRef.current.close();
+      }
+    };
+  }, []);
 
-  const addLink = () =>
-    setLinks((prev) => [
-      ...prev,
-      { id: crypto.randomUUID(), label: "", url: "" },
-    ]);
+  // Generate LaTeX code from form data
+  const generateLatexFromForm = useCallback(() => {
+    if (!formData.fullName.trim()) {
+      console.warn("Name is required to generate resume");
+      return "";
+    }
 
-  const updateLink = (
-    id: string,
-    patch: Partial<{ label: string; url: string }>
-  ) =>
-    setLinks((prev) => prev.map((l) => (l.id === id ? { ...l, ...patch } : l)));
+    const resumeData = {
+      name: formData.fullName,
+      title: formData.title,
+      email: formData.email,
+      phone: formData.phone,
+      location: formData.location,
+      website: formData.website,
+      summary: formData.summary,
+      skills: formData.skills
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+      experiences: formData.experiences.map((exp) => ({
+        company: exp.company,
+        role: exp.title,
+        start: exp.startDate,
+        end: exp.endDate,
+        bullets: exp.description.split("\n").filter(Boolean),
+      })),
+      education: formData.educations.map((edu) => ({
+        school: edu.institution,
+        degree: edu.degree,
+        start: edu.year,
+        end: edu.year,
+      })),
+      projects: formData.projects.map((proj) => ({
+        name: proj.name,
+        technologies: proj.technologies,
+        link: proj.link,
+        description: proj.description,
+      })),
+      customSections: customSections.map((section) => ({
+        title: section.title,
+        content: section.content,
+      })),
+      links: [
+        ...formData.links.map((link) => ({
+          label: link.label,
+          url: link.url,
+        })),
+        // Include projects as links if they have URLs (for backward compatibility)
+        ...formData.projects
+          .filter((proj) => proj.link)
+          .map((proj) => ({
+            label: proj.name,
+            url: proj.link,
+          })),
+      ],
+    };
 
-  const removeLink = (id: string) =>
-    setLinks((prev) => prev.filter((l) => l.id !== id));
+    return generateResumeTex(resumeData, latexSettings.selectedTemplate, {
+      pageSize: latexSettings.pageSize,
+      fontFamily: latexSettings.fontFamily,
+      primaryColor: latexSettings.primaryColor,
+      secondaryColor: latexSettings.secondaryColor,
+      sectionOrder: sections
+        .filter(s => s.type !== 'basic')
+        .sort((a, b) => a.order - b.order)
+        .map(s => {
+          if (s.type === 'skills') return 'skills';
+          if (s.type === 'custom') {
+            const customSection = customSections.find(cs => cs.id === s.id);
+            return customSection?.title ? `custom-${customSection.title.toLowerCase().replace(/\s+/g, '-')}` : 'custom';
+          }
+          return s.type;
+        }),
+    });
+  }, [
+    formData,
+    customSections,
+    latexSettings,
+    sections,
+  ]);
+
+  // Build PDF
+  const buildPdf = useCallback(
+    (texCode?: string) => {
+      if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) {
+        setError("WebSocket not connected. Please wait for connection...");
+        setLoading(false);
+        return;
+      }
+
+      const codeToCompile = texCode || latexCode || generateLatexFromForm();
+      setLoading(true);
+      setError(null);
+
+      // Set a timeout to prevent infinite loading
+      const timeout = setTimeout(() => {
+        setLoading(false);
+        setError("LaTeX compilation timed out. Please try again.");
+      }, 30000); // 30 second timeout
+
+      // Store timeout ID to clear it when we get a response
+      const timeoutId = timeout;
+
+      wsRef.current.send(
+        JSON.stringify({
+          type: "edit",
+          tex: codeToCompile,
+        })
+      );
+
+      // Clear timeout on success (we'll need to modify the message handler)
+      wsRef.current.addEventListener(
+        "message",
+        function handler() {
+          clearTimeout(timeoutId);
+          wsRef.current?.removeEventListener("message", handler);
+        },
+        { once: true }
+      );
+    },
+    [latexCode, generateLatexFromForm]
+  );
+
+  // Trigger initial build when WebSocket connects (only for form tab)
+  useEffect(() => {
+    if (wsConnected && formData.fullName && activeTab === "form" && autoRender) {
+      setTimeout(() => {
+        const initialLatex = generateLatexFromForm();
+        if (initialLatex) {
+          setLatexCode(initialLatex);
+          buildPdf(initialLatex);
+        }
+      }, 1000);
+    }
+  }, [wsConnected, formData.fullName, activeTab, autoRender, generateLatexFromForm, buildPdf]);
+
+  // Auto-build when form data changes (ONLY when in form tab)
+  useEffect(() => {
+    // Completely skip if not in form tab - this prevents overwriting LaTeX edits
+    if (activeTab !== "form") {
+      return;
+    }
+    
+    // Only auto-build if we're in form tab with auto-render on
+    if (autoRender) {
+      const timeoutId = setTimeout(() => {
+        const newLatexCode = generateLatexFromForm();
+        setLatexCode(newLatexCode);
+        buildPdf(newLatexCode);
+      }, 1000); // Debounce for 1 second
+
+      return () => clearTimeout(timeoutId);
+    }
+  }, [
+    activeTab,
+    autoRender,
+    formData,
+    customSections,
+    latexSettings,
+    sections,
+    generateLatexFromForm,
+    buildPdf
+  ]);
+
+  // Manual build
+  const manualBuild = () => {
+    const newLatexCode =
+      activeTab === "form" ? generateLatexFromForm() : latexCode;
+    if (activeTab === "form") {
+      setLatexCode(newLatexCode);
+    }
+    buildPdf(newLatexCode);
+  };
+
+  // Auto-build when LaTeX code changes (in LaTeX tab)
+  const debouncedLatexBuild = useCallback(() => {
+    if (autoRender && activeTab === "latex" && latexCode) {
+      buildPdf(latexCode);
+    }
+  }, [autoRender, activeTab, latexCode, buildPdf]);
+
+  useEffect(() => {
+    if (autoRender && activeTab === "latex" && latexCode) {
+      const timeoutId = setTimeout(debouncedLatexBuild, 5000); // 5 second debounce for LaTeX editing
+      return () => clearTimeout(timeoutId);
+    }
+  }, [latexCode, autoRender, activeTab, debouncedLatexBuild]);
+
+  // Smart tab switching
+  const handleTabSwitch = (newTab: "form" | "latex") => {
+    if (newTab === "latex" && activeTab === "form") {
+      // Switching to LaTeX tab - generate current LaTeX code from form
+      const currentLatex = generateLatexFromForm();
+      setLatexCode(currentLatex);
+    }
+    setActiveTab(newTab);
+  };
+
+  // Drag and Drop Functions
+  const handleDragStart = (e: React.DragEvent, sectionId: string) => {
+    setDraggedSection(sectionId);
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+  };
+
+  const handleDrop = (e: React.DragEvent, targetSectionId: string) => {
+    e.preventDefault();
+    if (!draggedSection || draggedSection === targetSectionId) return;
+
+    const newSections = [...sections];
+    const draggedIndex = newSections.findIndex(s => s.id === draggedSection);
+    const targetIndex = newSections.findIndex(s => s.id === targetSectionId);
+
+    if (draggedIndex !== -1 && targetIndex !== -1) {
+      // Remove dragged section and insert at target position
+      const [removed] = newSections.splice(draggedIndex, 1);
+      newSections.splice(targetIndex, 0, removed);
+      
+      // Update order values
+      newSections.forEach((section, index) => {
+        section.order = index;
+      });
+
+      setSections(newSections);
+    }
+    setDraggedSection(null);
+  };
+
+  const handleDragEnd = () => {
+    setDraggedSection(null);
+  };
+
+  // Form data change handler
+  const handleFormDataChange = (updates: Partial<ResumeFormData>) => {
+    setFormData(prev => ({ ...prev, ...updates }));
+  };
+
+  // LaTeX settings change handler
+  const handleLatexSettingsChange = (updates: Partial<LaTeXSettings>) => {
+    setLatexSettings(prev => ({ ...prev, ...updates }));
+  };
+
+  // PDF retry handler
+  const handleRetry = () => {
+    setError(null);
+    window.location.reload();
+  };
 
   return (
     <>
@@ -254,463 +420,58 @@ export default function ResumeEditorPage() {
           >
             <Header pageName="Resume Editor" />
             <div className="p-4 grid grid-cols-1 xl:grid-cols-2 gap-6">
-              {/* MAIN editor panel */}
+              {/* LEFT SIDE - Form & Controls */}
               <div className="space-y-6">
-                <section className="bg-white/5 border border-white/10 rounded-xl p-5">
-                  <h2 className="font-bold mb-4 text-sm tracking-wide">
-                    BASIC INFO
-                  </h2>
-                  <div className="grid md:grid-cols-2 gap-4">
-                    <div>
-                      <label className="text-xs text-gray-400">Full Name</label>
-                      <input
-                        value={fullName}
-                        onChange={(e) => setFullName(e.target.value)}
-                        className="mt-1 w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
-                        placeholder="John Doe"
-                      />
-                    </div>
-                    <div>
-                      <label className="text-xs text-gray-400">Title</label>
-                      <input
-                        value={title}
-                        onChange={(e) => setTitle(e.target.value)}
-                        className="mt-1 w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
-                        placeholder="Frontend Engineer"
-                      />
-                    </div>
-                  </div>
-                  <div className="mt-4">
-                    <label className="text-xs text-gray-400">
-                      Professional Summary
-                    </label>
-                    <textarea
-                      value={summary}
-                      onChange={(e) => setSummary(e.target.value)}
-                      rows={4}
-                      className="mt-1 w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm resize-y outline-none focus:border-white/30"
-                      placeholder="2–3 line impactful summary..."
-                    />
-                  </div>
-                  <div className="mt-4">
-                    <label className="text-xs text-gray-400">
-                      Skills (comma separated)
-                    </label>
-                    <input
-                      value={skills}
-                      onChange={(e) => setSkills(e.target.value)}
-                      className="mt-1 w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
-                      placeholder="React, TypeScript, Tailwind"
-                    />
-                  </div>
-                  {/* contact info grid */}
-                  <div className="mt-4 grid md:grid-cols-2 gap-4">
-                    <div>
-                      <label className="text-xs text-gray-400">Email</label>
-                      <input
-                        value={email}
-                        onChange={(e) => setEmail(e.target.value)}
-                        type="email"
-                        placeholder="john.doe@email.com"
-                        className="mt-1 w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
-                      />
-                    </div>
-                    <div>
-                      <label className="text-xs text-gray-400">Phone</label>
-                      <input
-                        value={phone}
-                        onChange={(e) => setPhone(e.target.value)}
-                        placeholder="+91 1234 5678 90"
-                        className="mt-1 w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
-                      />
-                    </div>
-                    <div>
-                      <label className="text-xs text-gray-400">Location</label>
-                      <input
-                        value={location}
-                        onChange={(e) => setLocation(e.target.value)}
-                        placeholder="City, Country / Remote"
-                        className="mt-1 w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
-                      />
-                    </div>
-                    <div>
-                      <label className="text-xs text-gray-400">
-                        Website / Primary Link
-                      </label>
-                      <input
-                        value={website}
-                        onChange={(e) => setWebsite(e.target.value)}
-                        placeholder="https://linkedin.com/in/username"
-                        className="mt-1 w-full bg-black/40 border border-white/10 rounded-md px-3 py-2 text-sm outline-none focus:border-white/30"
-                      />
-                    </div>
-                  </div>
+                {/* VIEW TABS */}
+                <ViewTabs
+                  activeTab={activeTab}
+                  autoRender={autoRender}
+                  loading={loading}
+                  onTabSwitch={handleTabSwitch}
+                  onAutoRenderChange={setAutoRender}
+                  onManualBuild={manualBuild}
+                />
 
-                  {/* additional links if user wants */}
-                  <div className="mt-6">
-                    <div className="flex items-center justify-between mb-2">
-                      <label className="text-xs text-gray-400">
-                        Additional Links
-                      </label>
-                      <button
-                        type="button"
-                        onClick={addLink}
-                        className="text-[11px] px-2 py-1 rounded bg-white text-black font-semibold hover:bg-gray-200"
-                      >
-                        + Add
-                      </button>
-                    </div>
-                    {links.length === 0 && (
-                      <p className="text-[11px] text-gray-500">
-                        (Optional) Add portfolio, GitHub, publications, etc.
-                      </p>
-                    )}
-                    <div className="space-y-2">
-                      {links.map((l) => (
-                        <div key={l.id} className="flex gap-2">
-                          <input
-                            value={l.label}
-                            onChange={(e) =>
-                              updateLink(l.id, { label: e.target.value })
-                            }
-                            placeholder="Label (e.g. GitHub)"
-                            className="flex-1 bg-black/40 border border-white/10 rounded-md px-2 py-1 text-xs outline-none focus:border-white/30"
-                          />
-                          <input
-                            value={l.url}
-                            onChange={(e) =>
-                              updateLink(l.id, { url: e.target.value })
-                            }
-                            placeholder="https://..."
-                            className="flex-[1.4] bg-black/40 border border-white/10 rounded-md px-2 py-1 text-xs outline-none focus:border-white/30"
-                          />
-                          <button
-                            onClick={() => removeLink(l.id)}
-                            className="text-gray-400 hover:text-red-400 text-xs px-2"
-                            title="Remove"
-                          >
-                            ×
-                          </button>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                </section>
+                {/* LATEX SETTINGS */}
+                <LaTeXSettingsPanel
+                  settings={latexSettings}
+                  onSettingsChange={handleLatexSettingsChange}
+                />
 
-                {/* REPLACED EXPERIENCE WITH GENERIC SECTIONS */}
-                <section className="bg-white/5 border border-white/10 rounded-xl p-5 space-y-8">
-                  <div className="flex items-center justify-between">
-                    <h2 className="font-bold text-sm tracking-wide">
-                      SECTIONS
-                    </h2>
-                    <button
-                      onClick={addSection}
-                      className="text-xs flex items-center gap-1 bg-white text-black font-semibold px-3 py-1.5 rounded-md hover:bg-gray-200"
-                    >
-                      <Plus className="h-3.5 w-3.5" />
-                      Add Section
-                    </button>
-                  </div>
-
-                  {sections.map((section, sIdx) => (
-                    <div
-                      key={section.id}
-                      className="border border-white/10 rounded-lg p-4 space-y-4 bg-black/40"
-                    >
-                      <div className="flex items-center gap-3">
-                        <input
-                          value={section.name}
-                          onChange={(e) =>
-                            updateSection(section.id, { name: e.target.value })
-                          }
-                          placeholder="Section Name (e.g. Experience, Education, Projects)"
-                          className="flex-1 bg-black/30 border border-white/10 rounded px-3 py-1.5 text-sm outline-none focus:border-white/30 font-semibold"
-                        />
-                        {sections.length > 1 && (
-                          <button
-                            onClick={() => removeSection(section.id)}
-                            className="text-gray-400 hover:text-red-400"
-                            title="Remove section"
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </button>
-                        )}
-                      </div>
-
-                      <div className="space-y-6">
-                        {section.entries.map((entry) => (
-                          <div
-                            key={entry.id}
-                            className="bg-black/30 border border-white/10 rounded-md p-4 space-y-3"
-                          >
-                            <div className="flex gap-3">
-                              <input
-                                value={entry.position}
-                                onChange={(e) =>
-                                  updateEntry(section.id, entry.id, {
-                                    position: e.target.value,
-                                  })
-                                }
-                                placeholder="Title / Role"
-                                className="flex-1 bg-black/40 border border-white/10 rounded px-2 py-1 text-sm outline-none focus:border-white/30"
-                              />
-                              <input
-                                value={entry.organization}
-                                onChange={(e) =>
-                                  updateEntry(section.id, entry.id, {
-                                    organization: e.target.value,
-                                  })
-                                }
-                                placeholder="Organization"
-                                className="flex-1 bg-black/40 border border-white/10 rounded px-2 py-1 text-sm outline-none focus:border-white/30"
-                              />
-                            </div>
-                            <div className="flex gap-3 items-center">
-                              <input
-                                type="month"
-                                value={entry.start}
-                                onChange={(e) =>
-                                  updateEntry(section.id, entry.id, {
-                                    start: e.target.value,
-                                  })
-                                }
-                                className="bg-black/40 border border-white/10 rounded px-2 py-1 text-sm outline-none focus:border-white/30"
-                              />
-                              <input
-                                type="month"
-                                value={entry.end}
-                                onChange={(e) =>
-                                  updateEntry(section.id, entry.id, {
-                                    end: e.target.value,
-                                  })
-                                }
-                                className="bg-black/40 border border-white/10 rounded px-2 py-1 text-sm outline-none focus:border-white/30"
-                              />
-                              <button
-                                onClick={() =>
-                                  removeEntry(section.id, entry.id)
-                                }
-                                className="ml-auto text-gray-400 hover:text-red-400"
-                                title="Remove entry"
-                              >
-                                <Trash2 className="h-4 w-4" />
-                              </button>
-                            </div>
-                            <div className="space-y-2">
-                              {entry.bullets.map((b, idx) => (
-                                <div
-                                  key={idx}
-                                  className="flex items-start gap-2"
-                                >
-                                  <textarea
-                                    value={b}
-                                    onChange={(e) =>
-                                      updateBullet(
-                                        section.id,
-                                        entry.id,
-                                        idx,
-                                        e.target.value
-                                      )
-                                    }
-                                    rows={1}
-                                    className="flex-1 bg-black/40 border border-white/10 rounded px-2 py-1 text-sm resize-y outline-none focus:border-white/30"
-                                    placeholder="Achievement / Detail..."
-                                  />
-                                  {entry.bullets.length > 1 && (
-                                    <button
-                                      onClick={() =>
-                                        removeBullet(section.id, entry.id, idx)
-                                      }
-                                      className="text-gray-500 hover:text-red-400"
-                                      title="Remove bullet"
-                                    >
-                                      <Trash2 className="h-4 w-4" />
-                                    </button>
-                                  )}
-                                </div>
-                              ))}
-                              <button
-                                onClick={() => addBullet(section.id, entry.id)}
-                                className="text-xs text-gray-300 hover:text-white"
-                              >
-                                + Add bullet
-                              </button>
-                            </div>
-
-                            {/* NEW LINK LABEL & URL INPUTS */}
-                            <div className="space-y-1">
-                              <label className="text-[10px] uppercase tracking-wide text-gray-400">
-                                Link
-                              </label>
-                              <div className="flex gap-3">
-                                <input
-                                  value={entry.linkLabel || ""}
-                                  onChange={(e) =>
-                                    updateEntry(section.id, entry.id, {
-                                      linkLabel: e.target.value,
-                                    })
-                                  }
-                                  placeholder="Link Label (e.g. Repo)"
-                                  className="flex-1 bg-black/40 border border-white/10 rounded px-2 py-1 text-xs outline-none focus:border-white/30"
-                                />
-                                <input
-                                  value={entry.linkUrl || ""}
-                                  onChange={(e) =>
-                                    updateEntry(section.id, entry.id, {
-                                      linkUrl: e.target.value,
-                                    })
-                                  }
-                                  placeholder="https://link"
-                                  className="flex-[1.4] bg-black/40 border border-white/10 rounded px-2 py-1 text-xs outline-none focus:border-white/30"
-                                />
-                              </div>
-                            </div>
-                          </div>
-                        ))}
-
-                        <button
-                          onClick={() => addEntry(section.id)}
-                          className="text-xs flex items-center gap-1 bg-white text-black font-semibold px-3 py-1.5 rounded-md hover:bg-gray-200"
-                        >
-                          <Plus className="h-3.5 w-3.5" />
-                          Add Entry
-                        </button>
-                      </div>
-                    </div>
-                  ))}
-                </section>
-
-                <section className="bg-white/5 border border-white/10 rounded-xl p-5">
-                  <h2 className="font-bold mb-4 text-sm tracking-wide flex items-center gap-2">
-                    <Bot className="h-4 w-4" /> AI SUGGESTIONS (Placeholder)
-                  </h2>
-                  <p className="text-xs text-gray-400">
-                    Maybe we can stream suggestions here? hook it up to our
-                    cloud model? placeholder for now, heres some examples
-                  </p>
-                  <div className="mt-3 text-sm space-y-2">
-                    <div className="p-3 rounded-md bg-black/40 border border-white/10">
-                      Add more quantified metrics in bullets.
-                    </div>
-                    <div className="p-3 rounded-md bg-black/40 border border-white/10">
-                      Tailor your skills to target role keywords for stronger
-                      ATS score.
-                    </div>
-                  </div>
-                </section>
+                {/* CONDITIONAL CONTENT */}
+                {activeTab === "form" ? (
+                  <ResumeForm
+                    formData={formData}
+                    sections={sections}
+                    customSections={customSections}
+                    draggedSection={draggedSection}
+                    onFormDataChange={handleFormDataChange}
+                    onSectionsChange={setSections}
+                    onCustomSectionsChange={setCustomSections}
+                    onDragStart={handleDragStart}
+                    onDragOver={handleDragOver}
+                    onDrop={handleDrop}
+                    onDragEnd={handleDragEnd}
+                  />
+                ) : (
+                  <LaTeXEditor
+                    latexCode={latexCode}
+                    onCodeChange={setLatexCode}
+                  />
+                )}
               </div>
 
-              {/* PREVIEW */}
-              <div className="space-y-6">
-                <section className="bg-white/5 border border-white/10 rounded-xl p-6">
-                  <div className="flex items-center justify-between mb-4">
-                    <h2 className="font-bold text-sm tracking-wide">
-                      LIVE PREVIEW
-                    </h2>
-                    <button className="text-xs bg-white text-black font-semibold px-3 py-1.5 rounded-md hover:bg-gray-200">
-                      Export (Coming Soon)
-                    </button>
-                  </div>
-                  <div className="bg-white text-black rounded-md p-8 text-sm leading-relaxed font-[350] shadow-inner">
-                    <h1 className="text-2xl font-semibold tracking-wide">
-                      {fullName || "John Doe"}
-                    </h1>
-                    <p className="uppercase tracking-wide text-xs mt-1 text-gray-600">
-                      {title || "Frontend Engineer"}
-                    </p>
-                    {([email, phone, location, website].some(Boolean) ||
-                      links.length > 0) && (
-                      <p className="text-[11px] mt-2 text-gray-700 flex flex-wrap gap-x-2 gap-y-1">
-                        {email && <span>{email}</span>}
-                        {phone && <span>{phone}</span>}
-                        {location && <span>{location}</span>}
-                        {website && <span>{website}</span>}
-                        {links
-                          .filter((l) => l.url || l.label)
-                          .map((l) => {
-                            const text = l.label || l.url;
-                            const href =
-                              l.url ||
-                              (l.label?.startsWith("http") ? l.label : "");
-                            return href ? (
-                              <a
-                                key={l.id}
-                                href={href}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="underline"
-                              >
-                                {text}
-                              </a>
-                            ) : (
-                              <span key={l.id}>{text}</span>
-                            );
-                          })}
-                      </p>
-                    )}
-                    <hr className="my-4 border-gray-300" />
-                    {summary && <p className="text-[13px] mb-4">{summary}</p>}
-                    <h3 className="font-semibold text-sm tracking-wide mb-1">
-                      SKILLS
-                    </h3>
-                    <p className="text-[12px] mb-4">
-                      {skills
-                        .split(",")
-                        .map((s) => s.trim())
-                        .filter(Boolean)
-                        .join(" • ")}
-                    </p>
-                    <h3 className="font-semibold text-sm tracking-wide mb-2">
-                      {/* Dynamic heading */}
-                    </h3>
-                    <div className="space-y-6">
-                      {sections.map((section) => (
-                        <div key={section.id}>
-                          <h4 className="font-semibold text-sm tracking-wide mb-2">
-                            {section.name || "Section"}
-                          </h4>
-                          <div className="space-y-4">
-                            {section.entries.map((entry) => (
-                              <div key={entry.id}>
-                                <div className="flex justify-between">
-                                  <p className="font-semibold text-[13px]">
-                                    {entry.position || "Title"}
-                                    {entry.organization ? " | " : ""}
-                                    {entry.organization}
-                                    {entry.linkUrl && (
-                                      <a
-                                        href={entry.linkUrl}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="ml-2 text-[11px] underline font-normal"
-                                      >
-                                        {entry.linkLabel || "Link"}
-                                      </a>
-                                    )}
-                                  </p>
-                                  <p className="text-[11px] text-gray-600">
-                                    {entry.start || "YYYY-MM"} -{" "}
-                                    {entry.end || "Present"}
-                                  </p>
-                                </div>
-                                <ul className="list-disc ml-4 mt-1 space-y-1">
-                                  {entry.bullets
-                                    .filter((b) => b.trim())
-                                    .map((b, i) => (
-                                      <li key={i} className="text-[12px]">
-                                        {b}
-                                      </li>
-                                    ))}
-                                </ul>
-                              </div>
-                            ))}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                    {/* we can leave the rest of preview unchanged */}
-                  </div>
-                </section>
+              {/* RIGHT SIDE - PDF Preview */}
+              <div className="space-y-6 xl:sticky xl:top-4 xl:h-screen xl:overflow-y-auto">
+                <PDFPreview
+                  pdfUrl={pdfUrl}
+                  loading={loading}
+                  error={error}
+                  wsConnected={wsConnected}
+                  zoomLevel={zoomLevel}
+                  onZoomChange={setZoomLevel}
+                  onRetry={handleRetry}
+                />
               </div>
             </div>
             <FooterSection />
@@ -718,9 +479,7 @@ export default function ResumeEditorPage() {
         </div>
       </SignedIn>
       <SignedOut>
-        <div className="bg-black text-white min-h-screen flex items-center justify-center">
-          <RedirectToSignIn />
-        </div>
+        <RedirectToSignIn />
       </SignedOut>
     </>
   );


### PR DESCRIPTION
This pull request introduces several new components for the resume editor and makes minor cleanups to the dashboard page. The primary focus is on enhancing the resume editing experience by providing modular components for editing content, LaTeX code, settings, previewing PDFs, and toggling between different views. Additionally, some commented-out code is removed from the dashboard for clarity.

**Resume Editor Component Additions:**

* Added `ResumeForm` component for dynamically rendering and managing resume sections, including drag-and-drop reordering, custom sections, and section-specific forms.
* Added `LaTeXEditor` component that provides a Monaco-based code editor for LaTeX, loaded dynamically to avoid SSR issues.
* Added `LaTeXSettingsPanel` component for configuring LaTeX template, page size, font, and colors, with controlled inputs for each setting.
* Added `PDFPreview` component for displaying resume PDF with zoom, download, and connection status, as well as error handling and retry logic.
* Added `ViewTabs` component for switching between form and LaTeX views, toggling auto-render, and manually building the PDF.

**Dashboard Code Cleanup:**

* Removed commented-out code for unused cards and sections in `frontend/app/dashboard/page.tsx` to improve readability and maintainability. [[1]](diffhunk://#diff-54582662993648e965cc23d26512f5d0867e5bc4813b038717bd399f0ca39d6aL294-L318) [[2]](diffhunk://#diff-54582662993648e965cc23d26512f5d0867e5bc4813b038717bd399f0ca39d6aL417-L445) [[3]](diffhunk://#diff-54582662993648e965cc23d26512f5d0867e5bc4813b038717bd399f0ca39d6aL462-R408)